### PR TITLE
Implement a login flow and redirect functionality.

### DIFF
--- a/app/catalogue/templates/catalogue/index.html
+++ b/app/catalogue/templates/catalogue/index.html
@@ -1,1 +1,1 @@
-{% extends 'layout.html' %}{% block title %}Catalogue{% endblock %}{% block content %}<h1>Catalogue</h1><p>Gestion des produits et articles.</p>{% endblock %}
+{% extends 'layout.html' %}{% block title %}Catalogue{% endblock %}{% block content %}<h1>Catalogue</h1><p>Gestion des produits et articles.</p><form id="catalogue_recherche" action="" method="post">  <input type="text" name="recherche" placeholder="Rechercher un article...">  <button type="submit">Rechercher</button></form>{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -3,4 +3,5 @@
 {% block content %}
   <h1 class="display-5 fw-bold">Bienvenue sur ESJ Application</h1>
   <p class="col-md-8 fs-4">Votre solution de gestion d'entreprise. Utilisez la barre de navigation pour commencer.</p>
+  <p><a href="{{ url_for('website.login') }}">Veuillez vous connecter pour continuer.</a></p>
 {% endblock %}

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -27,7 +27,7 @@
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('annuaire.index') }}">Annuaire</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('comptabilite.index') }}">Comptabilité</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('commande.index') }}">Commande</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('commande.index') }}">WebSite</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('website.index') }}">WebSite</a></li>
                 </ul>
                 <ul class="navbar-nav">
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('options.index') }}">Options</a></li>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,16 @@
+{% extends 'layout.html' %}
+{% block title %}Login{% endblock %}
+{% block content %}
+  <h2>Login</h2>
+  <form method="post" action="{{ url_for('website.login') }}">
+    <div>
+      <label for="username">Username</label>
+      <input type="text" id="username" name="username" required>
+    </div>
+    <div>
+      <label for="password">Password</label>
+      <input type="password" id="password" name="password" required>
+    </div>
+    <button type="submit">Login</button>
+  </form>
+{% endblock %}

--- a/app/website/routes.py
+++ b/app/website/routes.py
@@ -1,5 +1,14 @@
-from flask import Blueprint, render_template
+from flask import Blueprint, render_template, request, redirect, url_for
+
 bp = Blueprint('website', __name__)
+
 @bp.route('/')
 def index():
     return render_template('index.html')
+
+@bp.route('/login', methods=('GET', 'POST'))
+def login():
+    if request.method == 'POST':
+        # In a real app, you would check credentials here
+        return redirect(url_for('catalogue.index') + '#catalogue_recherche')
+    return render_template('login.html')


### PR DESCRIPTION
This commit introduces a new login page and a `/login` route. Upon a dummy login, you are redirected to the catalogue page.

Key changes:
- Created a login page at `/login`.
- Added a search form to the catalogue page to serve as a redirect anchor with the ID `catalogue_recherche`.
- Implemented the redirect from the login page to `/catalogue/#catalogue_recherche`.
- Added a link to the login page from the home page.

This change mimics the flow you requested in the issue, based on the provided example URL.